### PR TITLE
[fix] deps path resolve

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,8 +52,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 }
 
 async function serverBin(): Promise<string> {
-  const rootDir = await pkgDir(__dirname)
-  let bin = path.join(rootDir, 'node_modules', 'bash-language-server', 'bin', 'main.js')
+  let bin = require.resolve('bash-language-server/bin/main.js')
   try {
     bin = fs.realpathSync(bin)
   } catch (e) {


### PR DESCRIPTION
### Problem

when the deps are hosted and installed to an upper directory like this:

```text
~/.config/coc/extensions
└──node_modules
    └──coc-sh
    └──bash-language-server
```

In this case the `pkgDir` resolves to the wrong path: `~/.config/coc/extensions/node_modules/coc-sh/node_modules/bash-language-server`.

### Solution

`require.resolve` uses the native dependency loader `require` to find the path to the dependencies.